### PR TITLE
refactor: 폴더 이미지 조회/ 미분류 이미지 조회 api 분리

### DIFF
--- a/src/main/kotlin/com/keeply/api/folder/controller/FolderController.kt
+++ b/src/main/kotlin/com/keeply/api/folder/controller/FolderController.kt
@@ -49,19 +49,21 @@ class FolderController (
     }
 
     @GetMapping("/{folderId}")
-    @Operation(summary = "folderId로 폴더의 이미지 리스트 검색, 미분류 이미지 리스트 검색 API",
-        description = "폴더 검색시 folderId, 미분류 이미지 검색시, folderId = \"uncategorized\"")
+    @Operation(summary = "folderId로 폴더의 이미지 리스트 검색 API")
     fun getFolderImages(
         @AuthenticationPrincipal userDetails: CustomUserDetails,
-        @PathVariable @Positive folderId: String
+        @PathVariable(required = true) @Positive folderId: Long
     ): ApiResponse<FolderResponseDTO.FolderImages> {
-        val apiResponse = if (folderId == "uncategorized") {
-            folderService.getUncategorizedImages(userDetails.userId)
-        } else {
-            val parsedFolderId = folderId.toLongOrNull()
-                ?: throw InvalidFolderIdException()
-            folderService.getFolderImages(userDetails.userId, parsedFolderId)
-        }
+        val apiResponse = folderService.getFolderImages(userDetails.userId, folderId)
+        return apiResponse
+    }
+
+    @GetMapping("/uncategorized")
+    @Operation(summary = "미분류 이미지 리스트 검색 API")
+    fun getFolderImages(
+        @AuthenticationPrincipal userDetails: CustomUserDetails,
+    ): ApiResponse<FolderResponseDTO.FolderImages> {
+        val apiResponse = folderService.getUncategorizedImages(userDetails.userId)
         return apiResponse
     }
 

--- a/src/main/kotlin/com/keeply/api/folder/controller/FolderController.kt
+++ b/src/main/kotlin/com/keeply/api/folder/controller/FolderController.kt
@@ -60,7 +60,7 @@ class FolderController (
 
     @GetMapping("/uncategorized")
     @Operation(summary = "미분류 이미지 리스트 검색 API")
-    fun getFolderImages(
+    fun getUncategorizedImages(
         @AuthenticationPrincipal userDetails: CustomUserDetails,
     ): ApiResponse<FolderResponseDTO.FolderImages> {
         val apiResponse = folderService.getUncategorizedImages(userDetails.userId)


### PR DESCRIPTION
## 📝작업 내용

폴더 이미지 조회/ 미분류 이미지 조회 api 분리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 분류되지 않은 이미지를 조회하는 전용 API가 추가되어 해당 항목을 직접 불러올 수 있습니다.

* 리팩터링
  * 폴더 이미지 조회 API가 명확한 식별자 유형으로 정리되어 요청 처리 로직이 단순해졌습니다.
  * 특수 케이스를 전용 경로로 분리해 경로와 파라미터가 더 명확해지고 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->